### PR TITLE
Remove `noAssert` argument from buffer functions

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -47,7 +47,7 @@ exports.horspool = function (haystack, needle, start) {
     start = start || 0;
 
     for (let i = start; i <= haystack.length - needle.length;) {       // Has enough room to fit the entire needle
-        const lastChar = haystack.readUInt8(i + needle.lastPos, true);
+        const lastChar = haystack.readUInt8(i + needle.lastPos);
         if (lastChar === needle.last &&
             internals.startsWith(haystack, needle, i)) {
 
@@ -68,7 +68,7 @@ internals.startsWith = function (haystack, needle, pos) {
     }
 
     for (let i = 0; i < needle.lastPos; ++i) {
-        if (needle.value[i] !== haystack.readUInt8(pos + i, true)) {
+        if (needle.value[i] !== haystack.readUInt8(pos + i)) {
             return false;
         }
     }


### PR DESCRIPTION
The support for the `noAssert` argument dropped in Node.js 10.x.
This removes the argument therefore.

Refs: https://github.com/nodejs/node/pull/18395