### PR TITLE
fix duplicate 'close' events

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -6,9 +6,7 @@ const Hoek = require('@hapi/hoek');
 const Vise = require('@hapi/vise');
 
 
-const internals = {
-    close: parseInt(process.version.match(/^v(\d+)\./)[1], 10) < 14         // node 14 closes Writable streams automatically
-};
+const internals = {};
 
 
 exports.compile = function (needle) {
@@ -112,7 +110,7 @@ exports.Stream = internals.Stream = class extends Stream.Writable {
 
     constructor(needle) {
 
-        super();
+        super({ autoDestroy: true });
 
         this.needle(needle);
         this._haystack = new Vise();
@@ -126,14 +124,6 @@ exports.Stream = internals.Stream = class extends Stream.Writable {
             for (let i = 0; i < chunks.length; ++i) {
                 this.emit('haystack', chunks[i]);
             }
-
-            // $lab:coverage:off$
-
-            if (internals.close) {
-                setImmediate(() => this.emit('close'));     // Give pending events a chance to fire
-            }
-
-            // $lab:coverage:on$
         });
     }
 

--- a/test/index.js
+++ b/test/index.js
@@ -145,10 +145,18 @@ describe('Stream', () => {
         const result = [];
 
         const stream = new Nigel.Stream(Buffer.from('123'));
+        let closed = false;
         stream.on('close', () => {
 
             expect(result).to.equal(['abc', 1, 'de', 'fg', 1, 'hij1', 1, 'klm', 1, 'nop']);
-            team.attend();
+
+            // Verify that 'close' is only emitted once.
+            expect(closed).to.equal(false);
+            closed = true;
+            setImmediate(() => {
+
+                team.attend();
+            });
         });
 
         stream.on('needle', () => {


### PR DESCRIPTION
This commit ensures that the stream only emits the `'close'` event
once consistently across Node 12 and 14 without version detection.