### PR TITLE
Support node v18 and drop node v12

### DIFF
--- a/.github/workflows/ci-module.yml
+++ b/.github/workflows/ci-module.yml
@@ -10,3 +10,5 @@ on:
 jobs:
   test:
     uses: hapijs/.github/.github/workflows/ci-module.yml@master
+    with:
+      min-node-version: 14

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,5 +1,6 @@
-Copyright (c) 2014-2020, Sideway Inc, and project contributors  
-Copyright (c) 2014, Walmart.  
+Copyright (c) 2014-2022, Project contributors
+Copyright (c) 2014-2020, Sideway Inc
+Copyright (c) 2014, Walmart.
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:

--- a/README.md
+++ b/README.md
@@ -1,7 +1,15 @@
-<a href="http://hapijs.com"><img src="https://raw.githubusercontent.com/hapijs/assets/master/images/family.png" width="180px" align="right" /></a>
-
 # @hapi/nigel
 
-#### Boyer-Moore-Horspool algorithms.
+#### Boyer-Moore-Horspool algorithms
 
-[![Build Status](https://secure.travis-ci.org/hapijs/nigel.svg)](http://travis-ci.org/hapijs/nigel)
+**nigel** is part of the **hapi** ecosystem and was designed to work seamlessly with the [hapi web framework](https://hapi.dev) and its other components (but works great on its own or with other frameworks). If you are using a different web framework and find this module useful, check out [hapi](https://hapi.dev) – they work even better together.
+
+### Visit the [hapi.dev](https://hapi.dev) Developer Portal for tutorials, documentation, and support
+
+## Useful resources
+
+- [Documentation and API](https://hapi.dev/family/nigel/)
+- [Versions status](https://hapi.dev/resources/status/#nigel) (builds, dependencies, node versions, licenses, eol)
+- [Changelog](https://hapi.dev/family/nigel/changelog/)
+- [Project policies](https://hapi.dev/policies/)
+- [Free and commercial support options](https://hapi.dev/support/)

--- a/lib/index.js
+++ b/lib/index.js
@@ -3,7 +3,7 @@
 const Stream = require('stream');
 
 const Hoek = require('@hapi/hoek');
-const Vise = require('@hapi/vise');
+const { Vise } = require('@hapi/vise');
 
 
 const internals = {};
@@ -11,7 +11,7 @@ const internals = {};
 
 exports.compile = function (needle) {
 
-    Hoek.assert(needle && needle.length, 'Missing needle');
+    Hoek.assert(needle?.length, 'Missing needle');
     Hoek.assert(Buffer.isBuffer(needle), 'Needle must be a buffer');
 
     const profile = {
@@ -40,7 +40,7 @@ exports.horspool = function (haystack, needle, start) {
     Hoek.assert(haystack, 'Missing haystack');
 
     needle = (needle.badCharShift ? needle : exports.compile(needle));
-    start = start || 0;
+    start = start ?? 0;
 
     for (let i = start; i <= haystack.length - needle.length;) {       // Has enough room to fit the entire needle
         const lastChar = haystack.readUInt8(i + needle.lastPos);
@@ -76,7 +76,7 @@ internals.startsWith = function (haystack, needle, pos) {
 exports.all = function (haystack, needle, start) {
 
     needle = exports.compile(needle);
-    start = start || 0;
+    start = start ?? 0;
 
     const matches = [];
     for (let i = start; i !== -1 && i < haystack.length;) {
@@ -106,11 +106,11 @@ internals._indexOf = function (haystack, needle) {
 };
 
 
-exports.Stream = internals.Stream = class extends Stream.Writable {
+exports.Stream = class extends Stream.Writable {
 
     constructor(needle) {
 
-        super({ autoDestroy: true });
+        super();
 
         this.needle(needle);
         this._haystack = new Vise();

--- a/package.json
+++ b/package.json
@@ -1,11 +1,11 @@
 {
   "name": "@hapi/nigel",
-  "description": "BoyerMooreHorspool algorithms",
+  "description": "Boyer-Moore-Horspool algorithms",
   "version": "4.0.2",
   "repository": "git://github.com/hapijs/nigel",
   "main": "lib/index.js",
   "engines": {
-    "node": ">=12.0.0"
+    "node": ">=14.0.0"
   },
   "files": [
     "lib"
@@ -23,14 +23,14 @@
     ]
   },
   "dependencies": {
-    "@hapi/hoek": "^9.0.4",
-    "@hapi/vise": "^4.0.0"
+    "@hapi/hoek": "^10.0.0",
+    "@hapi/vise": "^5.0.0"
   },
   "devDependencies": {
-    "@hapi/code": "8.x.x",
+    "@hapi/code": "^9.0.0",
     "@hapi/eslint-plugin": "*",
-    "@hapi/lab": "24.x.x",
-    "@hapi/teamwork": "4.x.x"
+    "@hapi/lab": "^25.0.1",
+    "@hapi/teamwork": "^5.0.0"
   },
   "scripts": {
     "test": "lab -a @hapi/code -t 100 -L",

--- a/test/esm.js
+++ b/test/esm.js
@@ -1,0 +1,30 @@
+'use strict';
+
+const Code = require('@hapi/code');
+const Lab = require('@hapi/lab');
+
+
+const { before, describe, it } = exports.lab = Lab.script();
+const expect = Code.expect;
+
+
+describe('import()', () => {
+
+    let Nigel;
+
+    before(async () => {
+
+        Nigel = await import('../lib/index.js');
+    });
+
+    it('exposes all methods and classes as named imports', () => {
+
+        expect(Object.keys(Nigel)).to.equal([
+            'Stream',
+            'all',
+            'compile',
+            'default',
+            'horspool'
+        ]);
+    });
+});

--- a/test/index.js
+++ b/test/index.js
@@ -4,7 +4,7 @@ const Code = require('@hapi/code');
 const Lab = require('@hapi/lab');
 const Nigel = require('..');
 const Teamwork = require('@hapi/teamwork');
-const Vise = require('@hapi/vise');
+const { Vise } = require('@hapi/vise');
 
 
 const internals = {};


### PR DESCRIPTION
 - Test on node v14+, adopt some new syntax, utilize `autoDestroy` default.
 - Update to node v18-compatible versions of hapi modules.
 - Ensure all exports are available when used as ESM module.
 - Update readme to match standard format.

If this looks good, this will go out as nigel v5.